### PR TITLE
Ensure context is available in template, support Django2.0+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 dist
+*.pyc
+*.egg-info/
+.tox/
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,41 @@
 language: python
 
-python:
-  - "3.5"
-
-env:
-  - TOX_ENV=py35-django-18
-  - TOX_ENV=py34-django-18
-  - TOX_ENV=py33-django-18
-  - TOX_ENV=py27-django-18
-  - TOX_ENV=py35-django-19
-  - TOX_ENV=py34-django-19
-  - TOX_ENV=py27-django-19
-  - TOX_ENV=py35-django-110
-  - TOX_ENV=py34-django-110
-  - TOX_ENV=py27-django-110
-  - TOX_ENV=py36-django-111
-  - TOX_ENV=py35-django-111
-  - TOX_ENV=py34-django-111
-  - TOX_ENV=py27-django-111
-  - TOX_ENV=py36-django-master
-  - TOX_ENV=py35-django-master
-
 matrix:
+  include:
+    - python: 2.7
+      env: TOX_ENV=py27-django-18
+    - python: 2.7
+      env: TOX_ENV=py27-django-19
+    - python: 2.7
+      env: TOX_ENV=py27-django-110
+    - python: 2.7
+      env: TOX_ENV=py27-django-111
+    - python: 3.3
+      env: TOX_ENV=py33-django-18
+    - python: 3.3
+      env: TOX_ENV=py33-django-19
+    - python: 3.4
+      env: TOX_ENV=py34-django-18
+    - python: 3.4
+      env: TOX_ENV=py34-django-19
+    - python: 3.4
+      env: TOX_ENV=py34-django-110
+    - python: 3.4
+      env: TOX_ENV=py34-django-111
+    - python: 3.5
+      env: TOX_ENV=py35-django-18
+    - python: 3.5
+      env: TOX_ENV=py35-django-19
+    - python: 3.5
+      env: TOX_ENV=py35-django-110
+    - python: 3.5
+      env: TOX_ENV=py35-django-111
+    - python: 3.5
+      env: TOX_ENV=py35-django-master
+    - python: 3.6
+      env: TOX_ENV=py36-django-111
+    - python: 3.6
+      env: TOX_ENV=py36-django-master
   fast_finish: true
   allow_failures:
     - env: TOX_ENV=py35-django-master

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,37 +3,25 @@ language: python
 matrix:
   include:
     - python: 2.7
-      env: TOX_ENV=py27-django-18
-    - python: 2.7
-      env: TOX_ENV=py27-django-19
-    - python: 2.7
       env: TOX_ENV=py27-django-110
     - python: 2.7
       env: TOX_ENV=py27-django-111
-    - python: 3.3
-      env: TOX_ENV=py33-django-18
-    - python: 3.3
-      env: TOX_ENV=py33-django-19
-    - python: 3.4
-      env: TOX_ENV=py34-django-18
-    - python: 3.4
-      env: TOX_ENV=py34-django-19
     - python: 3.4
       env: TOX_ENV=py34-django-110
     - python: 3.4
       env: TOX_ENV=py34-django-111
     - python: 3.5
-      env: TOX_ENV=py35-django-18
-    - python: 3.5
-      env: TOX_ENV=py35-django-19
-    - python: 3.5
       env: TOX_ENV=py35-django-110
     - python: 3.5
       env: TOX_ENV=py35-django-111
     - python: 3.5
+      env: TOX_ENV=py35-django-20
+    - python: 3.5
       env: TOX_ENV=py35-django-master
     - python: 3.6
       env: TOX_ENV=py36-django-111
+    - python: 3.6
+      env: TOX_ENV=py36-django-20
     - python: 3.6
       env: TOX_ENV=py36-django-master
   fast_finish: true

--- a/navutils/breadcrumbs.py
+++ b/navutils/breadcrumbs.py
@@ -1,4 +1,8 @@
-from django.core.urlresolvers import reverse
+try:
+    # Django 1.10+
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 
 
 class Breadcrumb(object):

--- a/navutils/menu.py
+++ b/navutils/menu.py
@@ -1,4 +1,8 @@
-from django.core.urlresolvers import reverse
+try:
+    # Django 1.10+
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 
 from persisting_theory import Registry
 
@@ -153,13 +157,21 @@ class Node(object):
 class AnonymousNode(Node):
     """Only viewable by anonymous users"""
     def is_viewable_by(self, user, context={}):
-        return not user.is_authenticated()
+        try:
+            return not user.is_authenticated()
+        except TypeError:
+            # Django 2.0+
+            return not user.is_authenticated
 
 
 class AuthenticatedNode(Node):
     """Only viewable by authenticated users"""
     def is_viewable_by(self, user, context={}):
-        return user.is_authenticated()
+        try:
+            return user.is_authenticated()
+        except TypeError:
+            # Django 2.0+
+            return user.is_authenticated
 
 
 class StaffNode(AuthenticatedNode):

--- a/navutils/templatetags/navutils_tags.py
+++ b/navutils/templatetags/navutils_tags.py
@@ -29,8 +29,13 @@ def render_menu(context, menu, **kwargs):
         'current_menu_item': kwargs.get('current_menu_item', context.get('current_menu_item')),
         'menu_config': settings.NAVUTILS_MENU_CONFIG
     }
-    final_context = menu.get_context(c)
-    return t.render(final_context)
+    context.update(c)
+    final_context = menu.get_context(context)
+    try:
+        return t.render(final_context)
+    except TypeError:
+        # Django 2.0+
+        return t.render(final_context.flatten())
 
 @register.simple_tag(takes_context=True)
 def render_node(context, node, **kwargs):
@@ -71,9 +76,14 @@ def render_node(context, node, **kwargs):
         'start_depth': start_depth,
         'menu_config': settings.NAVUTILS_MENU_CONFIG
     }
-    final_context = node.get_context(c)
+    context.update(c)
+    final_context = node.get_context(context)
 
-    return t.render(final_context)
+    try:
+        return t.render(final_context)
+    except TypeError:
+        # Django 2.0+
+        return t.render(final_context.flatten())
 
 
 @register.simple_tag(takes_context=True)

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -408,3 +408,21 @@ class RenderMenuTest(BaseTestCase):
                 <li class="menu-item"><a href="http://test.com">Test</a></li>
             </ul>
             """)
+
+    def test_context_available_in_template(self):
+        main_menu = menu.Menu('main')
+        node = menu.Node('context', 'Context', url='http://test-context.com',
+                         template='test_app/test_node.html')
+        main_menu.register(node)
+
+        output = navutils_tags.render_menu({'foo': 'bar'}, menu=main_menu,
+                                           user=self.user)
+
+        self.assertHTMLEqual(
+            output,
+            """
+            <ul class="main-menu">
+                <li class="menu-item"><a href="http://test-context.com">Context bar</a></li>
+            </ul>
+            """
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+skip_missing_interpreters=true
 envlist =
     {py27,py33,py34,py35}-django-18
     {py27,py34,py35}-django-19

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 skip_missing_interpreters=true
 envlist =
-    {py27,py33,py34,py35}-django-18
-    {py27,py34,py35}-django-19
     {py27,py34,py35}-django-110
     {py27,py34,py35,py36}-django-111
     {py35,py36}-django-20
@@ -13,8 +11,6 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/navutils
 commands = py.test {posargs}
 deps =
-    django-18: Django>=1.8,<1.9
-    django-19: Django>=1.9,<1.10
     django-110: Django>=1.10,<1.11
     django-111: Django>=1.11,<1.12
     django-20: Django>=2.0,<2.1

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     {py27,py34,py35}-django-19
     {py27,py34,py35}-django-110
     {py27,py34,py35,py36}-django-111
+    {py35,py36}-django-20
     {py35,py36}-django-master
 
 [testenv]
@@ -14,7 +15,8 @@ deps =
     django-18: Django>=1.8,<1.9
     django-19: Django>=1.9,<1.10
     django-110: Django>=1.10,<1.11
-    django-111: Django>=1.11
+    django-111: Django>=1.11,<1.12
+    django-20: Django>=2.0,<2.1
     django-master: https://github.com/django/django/archive/master.tar.gz
     persisting-theory
     -r{toxinidir}/requirements/test.txt


### PR DESCRIPTION
Last PR #8 removed context passed from `render_menu` and `render_node` tags in templates.
This PR aims to fix that (plus support Django==2.0)