### PR TITLE
Application registry / custom AppConfig

### DIFF
--- a/navutils/apps.py
+++ b/navutils/apps.py
@@ -1,10 +1,9 @@
-from django.apps import AppConfig
+from django.apps import AppConfig, apps
 
-from django.conf import settings
 
 class App(AppConfig):
     name = 'navutils'
 
     def ready(self):
         from . import menu
-        menu.registry.autodiscover(settings.INSTALLED_APPS)
+        menu.registry.autodiscover((a.name for a in apps.get_app_configs()))

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist =
     {py27,py35,py36}-django-111
     {py35,py36,py37}-django-20
     {py35,py36,py37}-django-21
-    {py35,py36,py37}-django-master
+    {py35,py36,py37}-django-22
+    {py36,py37}-django-master
 
 [testenv]
 setenv =
@@ -14,6 +15,7 @@ deps =
     django-111: Django>=1.11,<1.12
     django-20: Django>=2.0,<2.1
     django-21: Django>=2.1,<2.2
+    django-22: Django>=2.2,<2.3
     django-master: https://github.com/django/django/archive/master.tar.gz
     persisting-theory
     -r{toxinidir}/requirements/test.txt


### PR DESCRIPTION
During autodiscovery, get installed apps from application registry 
(instead of `settings.INSTALLED_APPS`).
This allows use of custom AppConfig.

fixes EliotBerriot/django-navutils#10

Also updated tox tox settings to include Django 2.2, and removed py35
for Django master branch.