### PR TITLE
Adopt reverse notation for pattern_name

### DIFF
--- a/navutils/menu.py
+++ b/navutils/menu.py
@@ -109,7 +109,10 @@ class Node(object):
         :return: The target URL of the node, after reversing (if needed)
         """
         if self.pattern_name:
-            return reverse(self.pattern_name[0], args=self.pattern_name[1])
+            args = False
+            if len(self.pattern_name)>1:
+                args = self.pattern_name[1]
+            return reverse(self.pattern_name[0], args=args)
         return self.url
 
     def add(self, node):

--- a/navutils/menu.py
+++ b/navutils/menu.py
@@ -109,11 +109,7 @@ class Node(object):
         :return: The target URL of the node, after reversing (if needed)
         """
         if self.pattern_name:
-            expected_kwargs = {
-                key: value for key, value in kwargs.items()
-                if key in self.reverse_kwargs
-            }
-            return reverse(self.pattern_name, kwargs=expected_kwargs)
+            return reverse(self.pattern_name[0], args=self.pattern_name[1])
         return self.url
 
     def add(self, node):


### PR DESCRIPTION
Hello,

As discuss, my proposition to adopt reverse notation for **pattern_name**.

Notation could be now:

*without parameter*
``
pattern_name=['prestashop_connect:pads']
``

*with parameter*
``
 pattern_name=['products_manager:products_filtered', ['COM']]
``

Hope it could help.

Regards,

Thierry
